### PR TITLE
Change how balde is built

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,17 @@
 FROM ubuntu:14.04
 MAINTAINER Rafael G. Martins <rafael@rafaelmartins.eng.br>
 
+ENV version=0.1.2
+
 RUN apt-get update && apt-get install -y \
     pkg-config gettext zlib1g-dev libffi-dev \
     autoconf automake build-essential libtool libxml2-utils \
-    libfcgi-dev shared-mime-info libglib2.0-dev git peg \
+    libfcgi-dev shared-mime-info libglib2.0-dev wget peg ca-certificates \
     --no-install-recommends && apt-get clean
 
-RUN git clone https://github.com/balde/balde.git ~/balde
+RUN wget https://github.com/balde/balde/releases/download/v${version}/balde-${version}.tar.xz && tar xvf balde-${version}.tar.xz
 
-RUN cd ~/balde && \
+RUN cd balde-${version} && \
     ./autogen.sh && \
     ./configure --prefix=/usr && \
     make && \


### PR DESCRIPTION
This is to use release so, create a tag for the same version of balde and docker will build it and it will manage user to install the version it wants like in `docker pull balde/balde:0.1.2`
